### PR TITLE
Include longest alignment stats in reports

### DIFF
--- a/src/nanook/ParserRunnable.java
+++ b/src/nanook/ParserRunnable.java
@@ -103,6 +103,7 @@ public class ParserRunnable implements Runnable
                 AlignmentInfo ais = merger.endMergeAndStoreStats();
                 readReference.getStatsByType(stats.getType()).addCoverage(merger.getOverallHitStart(), merger.getOverallHitEnd()-merger.getOverallHitStart()+1);
                 readReference.getStatsByType(stats.getType()).getAlignmentsTableFile().writeMergedAlignment(stats, file.getName(), merger, ais);
+                readReference.getStatsByType(stats.getType()).addLongestAlignmentSize(ais.getAlignmentSize());
             }
         } catch (Exception e) {
             System.out.println("Error parsing alignment "+ alignmentPath);

--- a/src/nanook/ReadSet.java
+++ b/src/nanook/ReadSet.java
@@ -199,8 +199,8 @@ public class ReadSet {
         System.out.println("");
         
         stats.closeLengthsFile();
-        stats.writeSummaryFile();        
-        stats.calculateStats();    
+        stats.calculateStats(); 
+        stats.writeSummaryFile();           
         
         return nFastaFiles;
     }
@@ -321,8 +321,8 @@ public class ReadSet {
         System.out.println("");
         
         stats.closeLengthsFile();
-        stats.writeSummaryFile();        
-        stats.calculateStats();    
+        stats.calculateStats(); 
+        stats.writeSummaryFile();           
         
         return nFastaFiles;
     }    

--- a/src/nanook/ReadSetStats.java
+++ b/src/nanook/ReadSetStats.java
@@ -53,6 +53,7 @@ public class ReadSetStats implements Serializable {
     private int nDeletions = 0;
     private int ignoredDuplicates = 0;
     private int type;
+    private int longestAlignmentSize = 0;
    
     /**
      * Constructor
@@ -131,6 +132,17 @@ public class ReadSetStats implements Serializable {
             }
         }
         
+        // calculate the longest alignment size in the whole set
+        int longest = 0;
+        ArrayList<ReferenceSequence> sortedRefs = options.getReferences().getSortedReferences();
+        for (int i=0; i<sortedRefs.size(); i++) {
+            ReferenceSequence r = sortedRefs.get(i);
+            ReferenceSequenceStats refStats = r.getStatsByType(type);
+            if(refStats.getLongestAlignmentSize() > longest) {
+                longest = refStats.getLongestAlignmentSize();
+            }
+        }
+        longestAlignmentSize = longest;        
     }
     
     /**
@@ -442,6 +454,7 @@ public class ReadSetStats implements Serializable {
             pw.println("");
             pw.printf("Num reads without alignments: %d", nReadsWithoutAlignments);
             pw.println("");
+            pw.printf("Length of longest aligned read: %d", longestAlignmentSize);
             pw.close();
         } catch (IOException e) {
             System.out.println("writeSummaryFile exception:");
@@ -621,5 +634,9 @@ public class ReadSetStats implements Serializable {
     
     public int getIgnoredDuplicates() {
         return ignoredDuplicates;
+    }
+    
+    public int getLongestAlignmentSizeInSet() {
+        return longestAlignmentSize;
     }
 }

--- a/src/nanook/ReferenceSequenceStats.java
+++ b/src/nanook/ReferenceSequenceStats.java
@@ -51,6 +51,7 @@ public class ReferenceSequenceStats implements Serializable {
     private KmerTable readKmerTable = new KmerTable(5);
     private AlignmentsTableFile atf;
     private ArrayList<KmerAbundance> kmerAbundance = new ArrayList();
+    private int longestAlignmentSize = 0;
 
     /** 
      * Constructor.
@@ -544,5 +545,16 @@ public class ReferenceSequenceStats implements Serializable {
     
     public ArrayList getKmerAbundance() {
         return kmerAbundance;
+    }
+    
+    public int getLongestAlignmentSize() {
+        return longestAlignmentSize;
+    }
+    
+    public void addLongestAlignmentSize(int size) {
+        if(size > longestAlignmentSize) {
+            longestAlignmentSize = size;
+        }
+        
     }
 }

--- a/src/nanook/References.java
+++ b/src/nanook/References.java
@@ -274,7 +274,7 @@ public class References implements Serializable {
             PrintWriter pw = new PrintWriter(new FileWriter(filename));
             String formatString = "%-"+longestId+"s %-12s %-10s %-10s %-10s %-12s %-10s %-10s";
             //pw.printf(formatString, "ID", "Size", "ReadsAlign", "PcReads", "MeanLen", "TotalBases", "MeanCov", "LongPerfKm");    
-            pw.print("ID\tSize\tReadsAlign\tPcReads\tMeanLen\tTotalBases\tMeanCov\tLongPerfKm");
+            pw.print("ID\tSize\tReadsAlign\tPcReads\tMeanLen\tTotalBases\tMeanCov\tLongPerfKm\tLongestAlignment");
             pw.println("");
             
             //List<String> keys = new ArrayList<String>(referenceSeqIds.keySet());
@@ -283,7 +283,7 @@ public class References implements Serializable {
             //    referenceSeqIds.get(id).getStatsByType(type).writeSummary(pw, "%-"+longestId+"s %-12d %-10d %-10.2f %-10d");
             //}
 
-            formatString = "%s\t%d\t%d\t%.2f\t%.2f\t%d\t%.2f\t%d";
+            formatString = "%s\t%d\t%d\t%.2f\t%.2f\t%d\t%.2f\t%d\t%d";
             ArrayList<ReferenceSequence> sortedRefs = getSortedReferences();
             for (int i=0; i<sortedRefs.size(); i++) {
                 ReferenceSequence r = sortedRefs.get(i);
@@ -296,7 +296,9 @@ public class References implements Serializable {
                            refStats.getMeanReadLength(),
                            refStats.getTotalAlignedBases(),
                            (double)refStats.getTotalAlignedBases() / r.getSize(),
-                           refStats.getLongestPerfectKmer());
+                           refStats.getLongestPerfectKmer(),
+                           refStats.getLongestAlignmentSize());
+                
                 pw.println("");
             }
             

--- a/src/nanook/SampleReportWriter.java
+++ b/src/nanook/SampleReportWriter.java
@@ -179,6 +179,8 @@ public class SampleReportWriter {
         pw.println("");
         pw.printf("Number of reads without alignments & %d & (%.2f\\%%) \\\\", stats.getNumberOfReadsWithoutAlignments(), stats.getPercentOfReadsWithoutAlignments());
         pw.println("");
+        pw.printf("Longest alignment & %d \\\\", stats.getLongestAlignmentSizeInSet());
+        pw.println("");
         pw.println("\\end{tabular}");
         pw.println("}");
         pw.println("\\end{table}");
@@ -777,18 +779,18 @@ public class SampleReportWriter {
         pw.println("{\\footnotesize");
         if (references.getNumberOfReferences() < LONGTABLE_THRESHOLD) {
             pw.println("\\fontsize{9pt}{11pt}\\selectfont");
-            pw.println("\\begin{tabular}{l c c c c c c c}");
+            pw.println("\\begin{tabular}{l c c c c c c c c}");
         } else {
-            pw.println("\\begin{longtable}[l]{l c c c c c c c}");
+            pw.println("\\begin{longtable}[l]{l c c c c c c c c}");
         }
-        pw.println("          &             & {\\bf Number of} & {\\bf \\% of} & {\\bf Mean read} & {\\bf Aligned} & {\\bf Mean} & {\\bf Longest} \\\\");
-        pw.println("{\\bf ID} & {\\bf Size} & {\\bf Reads}     & {\\bf Reads}  & {\\bf length}    & {\\bf bases}   & {\\bf coverage} & {\\bf Perf Kmer} \\\\");
+        pw.println("          &             & {\\bf Number of} & {\\bf \\% of} & {\\bf Mean read} & {\\bf Aligned} & {\\bf Mean} & {\\bf Longest} & {\\bf Longest} \\\\");
+        pw.println("{\\bf ID} & {\\bf Size} & {\\bf Reads}     & {\\bf Reads}  & {\\bf length}    & {\\bf bases}   & {\\bf coverage} & {\\bf Perf Kmer} & {\\bf alignment} \\\\");
         ArrayList<ReferenceSequence> sortedRefs = references.getSortedReferences();
         for (int i=0; i<sortedRefs.size(); i++) {
             ReferenceSequence r = sortedRefs.get(i);
             ReferenceSequenceStats refStats = r.getStatsByType(type);
             if ((sortedRefs.size() < 100) || (refStats.getNumberOfReadsWithAlignments() > 0)) {
-                pw.printf("%s & %d & %d & %.2f & %.2f & %d & %.2f & %d \\\\",
+                pw.printf("%s & %d & %d & %.2f & %.2f & %d & %.2f & %d & %d \\\\",
                            r.getName().replaceAll("_", " "),
                            r.getSize(),
                            refStats.getNumberOfReadsWithAlignments(),
@@ -796,7 +798,8 @@ public class SampleReportWriter {
                            refStats.getMeanReadLength(),
                            refStats.getTotalAlignedBases(),
                            (double)refStats.getTotalAlignedBases() / r.getSize(),
-                           refStats.getLongestPerfectKmer());
+                           refStats.getLongestPerfectKmer(),
+                           refStats.getLongestAlignmentSize());
                 pw.println("");
             }
         }


### PR DESCRIPTION
Changes to write the longest alignment size to txt and pdf reports for each type. Also gives longest over all types.